### PR TITLE
logging for indexing jobs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,8 @@ module DiscoveryDispatcher
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
     config.autoload_paths += %W(#{config.root}/lib)
+
+    # Always include datetime, pid, and severity in all environments
+    config.log_formatter = ::Logger::Formatter.new
   end
 end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,11 +3,3 @@ require File.expand_path('../application', __FILE__)
 
 # Initialize the Rails application.
 Rails.application.initialize!
-
-class SimpleFormatter < ::Logger::Formatter
-  # This method is invoked when a log event occurs
-  def call(severity, timestamp, progname, msg)
-    date_format = timestamp.strftime('%Y-%m-%d %H:%M:%S')
-    "[#{date_format}] #{severity} (#{progname}): #{msg}\n"
-  end
-end

--- a/spec/discovery_dispatcher/indexing_job_spec.rb
+++ b/spec/discovery_dispatcher/indexing_job_spec.rb
@@ -6,6 +6,8 @@ describe DiscoveryDispatcher::IndexingJob do
         Rails.configuration.target_urls_hash = { 'target1' => { 'url' => 'http://localhost:3000' } }
         expect_any_instance_of(DiscoveryDispatcher::IndexingJob).to receive('build_request_url').with('xz404nk7341', 'http://localhost:3000', 'target1').and_return('RestClient.put "http://localhost:3000/items/xz404nk7341?target1", ""')
         expect_any_instance_of(DiscoveryDispatcher::IndexingJob).to receive('run_request').with('xz404nk7341', 'index', 'RestClient.put "http://localhost:3000/items/xz404nk7341?target1", ""')
+        expect(Rails.logger).to receive(:debug).with(/Processing/).and_call_original
+        expect(Rails.logger).to receive(:info).with(/Completed/).and_call_original
         index_job.perform
       end
     end


### PR DESCRIPTION
This PR fixes #34 by logging the datetime, pid, and benchmarked time for all indexed items. The log output goes to the default rails logger (i.e., `log/production.log`)
