### PR TITLE
Gemfile/Rakefile cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,46 +1,46 @@
 source 'https://rubygems.org'
 
-gem 'rails'
-gem 'responders'
-gem 'mysql2'
-gem 'jbuilder'
-gem 'sdoc', group: :doc
-gem 'spring', group: :development
-gem 'coveralls', require: false
-gem 'faraday'
-
-# Use Squash for exception reporting
-gem 'squash_ruby', require: 'squash/ruby'
+gem 'rails', '~> 4.2' # specifying because we expect a major version upgrade to break things
 
 # Pinned to 1.3.3 until https://github.com/SquareSquash/rails/pull/15
 gem 'squash_rails', '1.3.3', require: 'squash/rails'
 
 # Application specific gems
+gem 'daemons' # TODO: where is this used?
 gem 'delayed_job_active_record'
-gem 'rest-client'
-gem 'daemons'
-gem 'whenever', require: false
 gem 'delayed_job_web'
+gem 'faraday'
 gem 'is_it_working-cbeer'
+gem 'jbuilder' # TODO: where is this used?
+gem 'rake' # needed for automation tasks
+gem 'responders' # TODO: where is this used?
+gem 'rest-client'
+gem 'whenever', require: false
 
 group :development, :test do
-  gem 'rspec'
-  gem 'rspec-rails'
-  gem 'sqlite3'
-  gem 'vcr'
   gem 'dlss_cops'
+  gem 'sdoc'
+  gem 'spring'
+  gem 'sqlite3'
   gem 'yard'
 end
 
+group :production do
+  gem 'mysql2'
+end
+
 group :test do
+  gem 'coveralls', require: false
+  gem 'rspec-rails'
+  gem 'rspec'
+  gem 'vcr'
   gem 'webmock'
 end
 
 group :deployment do
-  gem 'capistrano', '~> 3.0'
-  gem 'capistrano-rvm'
-  gem 'capistrano-bundler'
-  gem 'capistrano-rails'
   gem 'dlss-capistrano'
+  gem 'capistrano-bundler'
   gem 'capistrano-passenger'
+  gem 'capistrano-rails'
+  gem 'capistrano-rvm'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,7 +255,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  capistrano (~> 3.0)
   capistrano-bundler
   capistrano-passenger
   capistrano-rails
@@ -270,7 +269,8 @@ DEPENDENCIES
   is_it_working-cbeer
   jbuilder
   mysql2
-  rails
+  rails (~> 4.2)
+  rake
   responders
   rest-client
   rspec
@@ -279,7 +279,6 @@ DEPENDENCIES
   spring
   sqlite3
   squash_rails (= 1.3.3)
-  squash_ruby
   vcr
   webmock
   whenever

--- a/Rakefile
+++ b/Rakefile
@@ -2,49 +2,11 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
+require 'rake'
 
 Rails.application.load_tasks
-
-require 'rake'
-require 'bundler'
-
-# Executed by the following command
-# cd /opt/app/lyberadmin/discovery-dispatcher/current && bundle exec rake RAILS_ENV=development discovery_dispatcher:query_purl_fetcher
-namespace :discovery_dispatcher do
-  task query_purl_fetcher: :environment do
-    DiscoveryDispatcher::Monitor.run
-    File.open('log/query_purl_fetcher.log', 'a') { |f| f.write("Read the new updated items in Purl fetcher at #{Time.now}\n") }
-  end
-end
-
-begin
-  Bundler.setup(:default, :development)
-rescue Bundler::BundlerError => e
-  $stderr.puts e.message
-  $stderr.puts 'Run `bundle install` to install missing gems'
-  exit e.status_code
-end
 
 task default: :ci
 
 desc 'run continuous integration suite (tests, coverage)'
 task ci: [:spec]
-
-# Use yard to build docs
-begin
-  require 'yard'
-  require 'yard/rake/yardoc_task'
-
-  project_root = File.expand_path(File.dirname(__FILE__))
-  doc_dest_dir = File.join(project_root, 'doc')
-
-  YARD::Rake::YardocTask.new(:doc) do |yt|
-    yt.files = Dir.glob(File.join(project_root, 'lib', '**', '*.rb'))
-    yt.options = ['--output-dir', doc_dest_dir, '--readme', 'README.md', '--title', 'Discovery Dispatcher Documentation']
-  end
-rescue LoadError
-  desc 'Generate YARD Documentation'
-  task :doc do
-    abort 'Please install the YARD gem to generate rdoc.'
-  end
-end

--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -1,5 +1,5 @@
 server 'discovery-dispatcher-dev.stanford.edu', user: fetch(:user), roles: %w{web db app}
-set :bundle_without, %w(sqlite test deployment).join(' ')
+set :bundle_without, %w(test deployment development).join(' ')
 
 Capistrano::OneTimeKey.generate_one_time_key!
-set :rails_env, 'development'
+set :rails_env, 'production'

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,5 +1,5 @@
 server 'discovery-dispatcher-prod.stanford.edu', user: fetch(:user), roles: %w{web db app}
-set :bundle_without, %w(sqlite test development deployment).join(' ')
+set :bundle_without, %w(test deployment development).join(' ')
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,5 +1,5 @@
 server 'discovery-dispatcher-stage.stanford.edu', user: fetch(:user), roles: %w{web db app}
-set :bundle_without, %w(sqlite test development deployment).join(' ')
+set :bundle_without, %w(test deployment development).join(' ')
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'

--- a/lib/tasks/discovery_dispatcher.rake
+++ b/lib/tasks/discovery_dispatcher.rake
@@ -1,0 +1,9 @@
+namespace :discovery_dispatcher do
+  # Executed by the following command
+  # cd /opt/app/lyberadmin/discovery-dispatcher/current && bundle exec rake RAILS_ENV=development discovery_dispatcher:query_purl_fetcher
+  desc 'Run the discovery dispatch monitor'
+  task query_purl_fetcher: :environment do
+    DiscoveryDispatcher::Monitor.run
+    File.open('log/query_purl_fetcher.log', 'a') { |f| f.write("Read the new updated items in Purl fetcher at #{Time.now}\n") }
+  end
+end

--- a/lib/tasks/yard.rake
+++ b/lib/tasks/yard.rake
@@ -1,0 +1,18 @@
+# Use yard to build docs
+begin
+  require 'yard'
+  require 'yard/rake/yardoc_task'
+
+  project_root = File.expand_path(File.dirname(__FILE__))
+  doc_dest_dir = File.join(project_root, 'doc')
+
+  YARD::Rake::YardocTask.new(:doc) do |yt|
+    yt.files = Dir.glob(File.join(project_root, 'lib', '**', '*.rb'))
+    yt.options = ['--output-dir', doc_dest_dir, '--readme', 'README.md', '--title', 'Discovery Dispatcher Documentation']
+  end
+rescue LoadError
+  desc 'Generate YARD Documentation'
+  task :doc do
+    abort 'Please install the YARD gem to generate rdoc.'
+  end
+end


### PR DESCRIPTION
This PR is a manual audit of the `Gemfile` to ensure that the gems are actually used, and that the groups are correct and correctly deployed. Note that for the latter, the `dev` environment runs in `production` mode.

This PR also cleans up the `Rakefile` by removing unneeded code for requiring bundler stuff (which already done correctly by `Rails.application`), and moves the task definitions into `.rake` files in `lib/tasks`.
