### PR TITLE
pass PurlFetcher API dates in default zone

### DIFF
--- a/lib/discovery_dispatcher/monitor.rb
+++ b/lib/discovery_dispatcher/monitor.rb
@@ -7,8 +7,8 @@ module DiscoveryDispatcher
     # @raise an error if the method faces any problem in reading from purl-fetcher-reader
     def self.run
       # Prepare start and end time
-      start_time = DiscoveryDispatcher::PurlFetcherManager.next_start_time
-      end_time = Time.now.in_time_zone('Pacific Time (US & Canada)').iso8601
+      start_time = DiscoveryDispatcher::PurlFetcherManager.next_start_time.iso8601
+      end_time = Time.zone.now.iso8601
 
       deletes = PurlFetcher::API.new.deletes(first_modified: start_time, last_modified: end_time).map do |record|
         PurlFetcher::RecordDeletes.new(record.deep_symbolize_keys).enqueue

--- a/lib/discovery_dispatcher/purl_fetcher_manager.rb
+++ b/lib/discovery_dispatcher/purl_fetcher_manager.rb
@@ -3,20 +3,19 @@ require 'time'
 module DiscoveryDispatcher
   # It manages the reading time from the purl-fetcher server
   # @example Get the next start time
-  #   DiscoveryDispatcher::PurlFetcherManager.PurlFetcherManager
+  #   DiscoveryDispatcher::PurlFetcherManager.next_start_time
   class PurlFetcherManager
-    PACIFIC_TIME_ZONE = 'Pacific Time (US & Canada)'.freeze
-
-    # @return the next start time to read the records from purl-fetcher. It will be the last reading time - 2 minutes.
+    # @return the next start time to read the records from purl-fetcher in UTC. It will be the last reading time - 2 minutes. `nil` if never run
     def self.next_start_time
-      next_start_time = ReaderLogRecords.maximum(:last_read_time)
-      next_start_time.nil? ? Time.parse('1970-01-01T12:00:00-08:00').in_time_zone(PACIFIC_TIME_ZONE).iso8601 : (next_start_time - 2.minutes).in_time_zone(PACIFIC_TIME_ZONE).iso8601
+      next_start_time = ReaderLogRecords.maximum(:last_read_time) # in UTC
+      next_start_time -= 2.minutes unless next_start_time.nil? # TODO: why add slop?
+      next_start_time
     end
 
     # @param last_read_time [Time] the end time for the last visit to purl-fetcher
     # @param no_of_records [int] the number of records that have been read on the last visit to purl-fetcher
     def self.set_last_fetch_info(last_read_time, no_of_records)
-      ReaderLogRecords.create(last_read_time: last_read_time.in_time_zone(PACIFIC_TIME_ZONE), record_count: no_of_records)
+      ReaderLogRecords.create(last_read_time: last_read_time, record_count: no_of_records)
     end
   end
 end

--- a/spec/discovery_dispatcher/purl_fetcher_manager_spec.rb
+++ b/spec/discovery_dispatcher/purl_fetcher_manager_spec.rb
@@ -12,12 +12,12 @@ describe DiscoveryDispatcher::PurlFetcherManager do
       ReaderLogRecords.create(last_read_time: '2012-01-01T12:00:00 -0800', record_count: 1)
 
       start_time = described_class.next_start_time
-      expect(start_time).to eq('2012-01-01T11:58:00-08:00')
+      expect(start_time).to eq('2012-01-01T11:58:00-08:00') # note this is minus 2 mins
     end
 
-    it 'returns 1970 as the start time for empty table' do
+    it 'returns nil as the start time for empty table' do
       start_time = described_class.next_start_time
-      expect(start_time).to eq('1970-01-01T12:00:00-08:00')
+      expect(start_time).to be_nil
     end
   end
 


### PR DESCRIPTION
This PR ensures that we pass the dates to the PurlFetcher API in ISO8601 format in the locally configured Rails timezone (which is UTC by default).

Also, if the `next_start_time` is nil, then the API will use the default, so we don't need to compute it (i.e., removes the `Time.parse('1970-01-01T12:00:00-08:00')` business).

See https://github.com/sul-dlss/discovery-indexing/issues/24
