### PR TITLE
log enqueueing of jobs

### DIFF
--- a/app/models/purl_fetcher/record_changes.rb
+++ b/app/models/purl_fetcher/record_changes.rb
@@ -20,6 +20,7 @@ module PurlFetcher
           DiscoveryDispatcher::IndexingJob.new('delete', druid, false_target)
         )
       end
+      Delayed::Worker.logger.info "Enqueued changes jobs for #{druid}"
     end
   end
 end

--- a/app/models/purl_fetcher/record_deletes.rb
+++ b/app/models/purl_fetcher/record_deletes.rb
@@ -15,6 +15,7 @@ module PurlFetcher
           DiscoveryDispatcher::DeleteFromAllIndexesJob.new('delete', druid, target[0].to_s.downcase)
         )
       end
+      Delayed::Worker.logger.info "Enqueued delete jobs for #{druid}"
     end
   end
 end

--- a/spec/models/purl_fetcher/record_changes_spec.rb
+++ b/spec/models/purl_fetcher/record_changes_spec.rb
@@ -15,6 +15,7 @@ describe PurlFetcher::RecordChanges do
       it 'are enqueued' do
         expect(Delayed::Job).to receive(:enqueue).with(DiscoveryDispatcher::IndexingJob.new('index', 'abc123', 'SearchWorks'))
         expect(Delayed::Job).to receive(:enqueue).with(DiscoveryDispatcher::IndexingJob.new('index', 'abc123', 'Revs'))
+        expect(Delayed::Worker.logger).to receive(:info).with(/Enqueued changes/)
         subject.enqueue
       end
     end
@@ -24,6 +25,7 @@ describe PurlFetcher::RecordChanges do
       end
       it 'are enqueued' do
         expect(Delayed::Job).to receive(:enqueue).with(DiscoveryDispatcher::IndexingJob.new('delete', 'abc123', 'EarthWorks'))
+        expect(Delayed::Worker.logger).to receive(:info).with(/Enqueued changes/)
         subject.enqueue
       end
     end

--- a/spec/models/purl_fetcher/record_deletes_spec.rb
+++ b/spec/models/purl_fetcher/record_deletes_spec.rb
@@ -15,6 +15,7 @@ describe PurlFetcher::RecordDeletes do
       it 'enqueue a delete job' do
         expect(Delayed::Job).to receive(:enqueue).with(DiscoveryDispatcher::DeleteFromAllIndexesJob.new('delete', 'abc123', 'searchworkspreview'))
         expect(Delayed::Job).to receive(:enqueue).with(DiscoveryDispatcher::DeleteFromAllIndexesJob.new('delete', 'abc123', 'searchworks'))
+        expect(Delayed::Worker.logger).to receive(:info).with(/Enqueued delete/)
         subject.enqueue
       end
     end


### PR DESCRIPTION
This PR is connected to #89, and adds simple logs on successful enqueued jobs. @lmcglohon 
