### PR TITLE
increase workers to 8

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -28,4 +28,4 @@ set :honeybadger_env, "#{fetch(:stage)}"
 set :whenever_identifier, -> { "#{fetch(:application)}_#{fetch(:stage)}" }
 
 # delayed_jobs workers
-set :delayed_job_workers, 4
+set :delayed_job_workers, 8


### PR DESCRIPTION
This PR fixes #67. @eefahy  Note that we need to document somewhere that you cannot run a `query_purl_fetcher` without having the workings actively running because of the massive performance problems with DelayedJobs when the queueing table gets large.
