### PR TITLE
use 24.hours as the latency threshold -- max time a job sits waiting in the queue

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -17,5 +17,4 @@ end
 OkComputer::Registry.register 'version', VersionCheck.new
 
 # Built-in Sidekiq check
-OkComputer::Registry.register 'sidekiq', OkComputer::SidekiqLatencyCheck.new('default')
-
+OkComputer::Registry.register 'sidekiq', OkComputer::SidekiqLatencyCheck.new('default', 24.hours)


### PR DESCRIPTION
This PR is connected to #112. It bumps the threshold to 24 hours -- latency is the length of time a job spends in the queue. @eefahy 
