### PR TITLE
Update okcomputer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ GEM
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
-    okcomputer (1.11.1)
+    okcomputer (1.13.0)
     parser (2.3.1.2)
       ast (~> 2.2)
     pkg-config (1.1.7)
@@ -296,4 +296,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.12.5
+   1.13.5

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -17,4 +17,4 @@ end
 OkComputer::Registry.register 'version', VersionCheck.new
 
 # Built-in Sidekiq check
-OkComputer::Registry.register 'sidekiq', OkComputer::SidekiqLatencyCheck.new('default', 24.hours)
+OkComputer::Registry.register 'feature-sidekiq', OkComputer::SidekiqLatencyCheck.new('default', 24.hours)


### PR DESCRIPTION
@eefahy This PR is connected to https://github.com/sul-dlss/discovery-indexing/issues/44. It upgrades OkComputer to use 1.13 and renames the sidekiq check to `/status/feature-sidekiq`.
