### PR TITLE
Explicitly load Git SCM in Capfile

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -3,6 +3,8 @@ require 'capistrano/setup'
 
 # Includes default deployment tasks
 require 'capistrano/deploy'
+require 'capistrano/scm/git'
+install_plugin Capistrano::SCM::Git
 
 require 'capistrano/bundler'
 require 'dlss/capistrano'


### PR DESCRIPTION
```
[Deprecation Notice] Future versions of Capistrano will not load the Git SCM
plugin by default. To silence this deprecation warning, add the following to
your Capfile after `require "capistrano/deploy"`:

    require "capistrano/scm/git"
    install_plugin Capistrano::SCM::Git
```